### PR TITLE
Substitute the oil ingredient

### DIFF
--- a/cake-recipe.txt
+++ b/cake-recipe.txt
@@ -7,7 +7,7 @@ Ingredients:
  - 1 teaspoon salt
  - 2 eggs
  - 1 cup milk
- - 1/2 cup vegetable oil
+ - 1/2 cup canoil oil
  - 2 teaspoons vanilla extract
  - 1 cup boiling water
 


### PR DESCRIPTION
The oil ingredient is misspelled.
